### PR TITLE
Fix Decimal type `+=` operator

### DIFF
--- a/ELCodable/Decimal.swift
+++ b/ELCodable/Decimal.swift
@@ -219,7 +219,7 @@ public postfix func ++(inout lhs: Decimal) -> Decimal {
 }
 
 public func +=(inout lhs: Decimal, rhs: Decimal) -> Decimal {
-    lhs = Decimal(lhs.value.decimalNumberBySubtracting(rhs.value))
+    lhs = Decimal(lhs.value.decimalNumberByAdding(rhs.value))
     return lhs
 }
 


### PR DESCRIPTION
#### What does this PR do?

Fixes a (copy-paste) error in Decimal type `+=` operator.
#### How should this be manually tested?

``` swift
var a: Decimal = 1
let b: Decimal = 2

a += b

print(a) // Should print `3`, not `-1`
```
