### PR TITLE
Remove return values from compound operators

### DIFF
--- a/ELCodable/Decimal.swift
+++ b/ELCodable/Decimal.swift
@@ -270,7 +270,7 @@ public func -=(inout lhs: Decimal, rhs: Double) -> Decimal {
 
 // MARK: Multiplication operators
 
-public func *(inout lhs: Decimal, rhs: Decimal) -> Decimal {
+public func *(lhs: Decimal, rhs: Decimal) -> Decimal {
     return Decimal(lhs.value.decimalNumberByMultiplyingBy(rhs.value))
 }
 

--- a/ELCodable/Decimal.swift
+++ b/ELCodable/Decimal.swift
@@ -218,19 +218,16 @@ public postfix func ++(inout lhs: Decimal) -> Decimal {
     return lhs
 }
 
-public func +=(inout lhs: Decimal, rhs: Decimal) -> Decimal {
+public func +=(inout lhs: Decimal, rhs: Decimal) {
     lhs = Decimal(lhs.value.decimalNumberByAdding(rhs.value))
-    return lhs
 }
 
-public func +=(inout lhs: Decimal, rhs: Int) -> Decimal {
+public func +=(inout lhs: Decimal, rhs: Int) {
     lhs = Decimal(lhs.value.decimalNumberByAdding(NSDecimalNumber(integer: rhs)))
-    return lhs
 }
 
-public func +=(inout lhs: Decimal, rhs: Double) -> Decimal {
+public func +=(inout lhs: Decimal, rhs: Double) {
     lhs = Decimal(lhs.value.decimalNumberByAdding(NSDecimalNumber(double: rhs)))
-    return lhs
 }
 
 // MARK: Subtraction operators
@@ -252,19 +249,16 @@ public postfix func --(inout lhs: Decimal) -> Decimal {
     return lhs
 }
 
-public func -=(inout lhs: Decimal, rhs: Decimal) -> Decimal {
+public func -=(inout lhs: Decimal, rhs: Decimal) {
     lhs = Decimal(lhs.value.decimalNumberBySubtracting(rhs.value))
-    return lhs
 }
 
-public func -=(inout lhs: Decimal, rhs: Int) -> Decimal {
+public func -=(inout lhs: Decimal, rhs: Int) {
     lhs = Decimal(lhs.value.decimalNumberBySubtracting(NSDecimalNumber(integer: rhs)))
-    return lhs
 }
 
-public func -=(inout lhs: Decimal, rhs: Double) -> Decimal {
+public func -=(inout lhs: Decimal, rhs: Double) {
     lhs = Decimal(lhs.value.decimalNumberBySubtracting(NSDecimalNumber(double: rhs)))
-    return lhs
 }
 
 
@@ -274,19 +268,16 @@ public func *(lhs: Decimal, rhs: Decimal) -> Decimal {
     return Decimal(lhs.value.decimalNumberByMultiplyingBy(rhs.value))
 }
 
-public func *=(inout lhs: Decimal, rhs: Decimal) -> Decimal {
+public func *=(inout lhs: Decimal, rhs: Decimal) {
     lhs = Decimal(lhs.value.decimalNumberByMultiplyingBy(rhs.value))
-    return lhs
 }
 
-public func *=(inout lhs: Decimal, rhs: Int) -> Decimal {
+public func *=(inout lhs: Decimal, rhs: Int) {
     lhs = Decimal(lhs.value.decimalNumberByMultiplyingBy(NSDecimalNumber(integer: rhs)))
-    return lhs
 }
 
-public func *=(inout lhs: Decimal, rhs: Double) -> Decimal {
+public func *=(inout lhs: Decimal, rhs: Double) {
     lhs = Decimal(lhs.value.decimalNumberByMultiplyingBy(NSDecimalNumber(double: rhs)))
-    return lhs
 }
 
 // MARK: Division operators
@@ -295,19 +286,16 @@ public func /(lhs: Decimal, rhs: Decimal) -> Decimal {
     return Decimal(lhs.value.decimalNumberByDividingBy(rhs.value))
 }
 
-public func /=(inout lhs: Decimal, rhs: Decimal) -> Decimal {
+public func /=(inout lhs: Decimal, rhs: Decimal) {
     lhs = Decimal(lhs.value.decimalNumberByDividingBy(rhs.value))
-    return lhs
 }
 
-public func /=(inout lhs: Decimal, rhs: Int) -> Decimal {
+public func /=(inout lhs: Decimal, rhs: Int) {
     lhs = Decimal(lhs.value.decimalNumberByDividingBy(NSDecimalNumber(integer: rhs)))
-    return lhs
 }
 
-public func /=(inout lhs: Decimal, rhs: Double) -> Decimal {
+public func /=(inout lhs: Decimal, rhs: Double) {
     lhs = Decimal(lhs.value.decimalNumberByDividingBy(NSDecimalNumber(double: rhs)))
-    return lhs
 }
 
 // MARK: Power-of operators


### PR DESCRIPTION
#### What does this PR do?

Changes the compound operators (`+=`, `-=`, `*=`, `/=`) to have return type `Void` so that they are in line with the Swift conventions.

(Also, I removed an unnecessary `inout` from the multiply operator `*`)
#### Any background context you want to provide?

The compound operators that are part of stdlib do not return the updated value. There is a brief mention of it [here](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md#advantages-of-these-operators), and I think these operators are defined in the stdlib [here](https://github.com/apple/swift/blob/master/stdlib/public/core/Stride.swift).

For example, with `Int`s:

``` swift
var a: Int = 1
let b: Int = 2

let result = (a += b)
print(result) // prints "()", aka Void
```

And with `Decimal`s:

``` swift
var a: Decimal = 1
let b: Decimal = 2

let result = (a += b)
print(result) // prints "3"
```
