### PR TITLE
Add a static framework target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
 osx_image: xcode9.3
 script:
-   - xcodebuild -project ELCodable.xcodeproj -scheme ELCodable -sdk iphonesimulator test -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELCodable.xcodeproj -scheme ELCodable -sdk iphonesimulator clean test -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELCodable.xcodeproj -scheme ELCodable_static -sdk iphonesimulator clean build -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' CODE_SIGNING_REQUIRED=NO

--- a/ELCodable.xcodeproj/project.pbxproj
+++ b/ELCodable.xcodeproj/project.pbxproj
@@ -7,6 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3EA176DD20E44AE600D50AF4 /* DecodeOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F351BF4AD6C006459C7 /* DecodeOperators.swift */; };
+		3EA176DE20E44AE600D50AF4 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F3F1BF4AD80006459C7 /* JSON.swift */; };
+		3EA176DF20E44AE600D50AF4 /* Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F331BF4AD6C006459C7 /* Decodable.swift */; };
+		3EA176E020E44AE600D50AF4 /* DecodableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F341BF4AD6C006459C7 /* DecodableExtensions.swift */; };
+		3EA176E120E44AE600D50AF4 /* Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F391BF4AD79006459C7 /* Encodable.swift */; };
+		3EA176E220E44AE600D50AF4 /* EncodableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F3A1BF4AD79006459C7 /* EncodableExtensions.swift */; };
+		3EA176E320E44AE600D50AF4 /* EncodeOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F3B1BF4AD79006459C7 /* EncodeOperators.swift */; };
+		3EA176E420E44AE600D50AF4 /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F411BF4AD92006459C7 /* Decimal.swift */; };
+		3EA176E720E44AE600D50AF4 /* ELCodable.h in Headers */ = {isa = PBXBuildFile; fileRef = CA0C9F191BF4AD08006459C7 /* ELCodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA0C9F1A1BF4AD08006459C7 /* ELCodable.h in Headers */ = {isa = PBXBuildFile; fileRef = CA0C9F191BF4AD08006459C7 /* ELCodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA0C9F211BF4AD08006459C7 /* ELCodable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA0C9F161BF4AD08006459C7 /* ELCodable.framework */; };
 		CA0C9F261BF4AD08006459C7 /* ELCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C9F251BF4AD08006459C7 /* ELCodableTests.swift */; };
@@ -59,6 +68,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3EA176ED20E44AE600D50AF4 /* ELCodable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELCodable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA0C9F161BF4AD08006459C7 /* ELCodable.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELCodable.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA0C9F191BF4AD08006459C7 /* ELCodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ELCodable.h; sourceTree = "<group>"; };
 		CA0C9F1B1BF4AD08006459C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -92,6 +102,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3EA176E520E44AE600D50AF4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA0C9F121BF4AD08006459C7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -143,6 +160,7 @@
 				CA0C9F201BF4AD08006459C7 /* ELCodableTests.xctest */,
 				CAE55BFE1D13A61900411727 /* ELCodable.framework */,
 				CAE55C071D13A61A00411727 /* ELCodable_osxTests.xctest */,
+				3EA176ED20E44AE600D50AF4 /* ELCodable.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -236,6 +254,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		3EA176E620E44AE600D50AF4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EA176E720E44AE600D50AF4 /* ELCodable.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA0C9F131BF4AD08006459C7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -255,6 +281,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		3EA176DB20E44AE600D50AF4 /* ELCodable_static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EA176E920E44AE600D50AF4 /* Build configuration list for PBXNativeTarget "ELCodable_static" */;
+			buildPhases = (
+				3EA176DC20E44AE600D50AF4 /* Sources */,
+				3EA176E520E44AE600D50AF4 /* Frameworks */,
+				3EA176E620E44AE600D50AF4 /* Headers */,
+				3EA176E820E44AE600D50AF4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ELCodable_static;
+			productName = ELCodable;
+			productReference = 3EA176ED20E44AE600D50AF4 /* ELCodable.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		CA0C9F151BF4AD08006459C7 /* ELCodable */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CA0C9F2A1BF4AD08006459C7 /* Build configuration list for PBXNativeTarget "ELCodable" */;
@@ -368,6 +412,7 @@
 			projectRoot = "";
 			targets = (
 				CA0C9F151BF4AD08006459C7 /* ELCodable */,
+				3EA176DB20E44AE600D50AF4 /* ELCodable_static */,
 				CA0C9F1F1BF4AD08006459C7 /* ELCodableTests */,
 				CAE55BFD1D13A61900411727 /* ELCodable_osx */,
 				CAE55C061D13A61A00411727 /* ELCodable_osxTests */,
@@ -376,6 +421,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3EA176E820E44AE600D50AF4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA0C9F141BF4AD08006459C7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -411,6 +463,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3EA176DC20E44AE600D50AF4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EA176DD20E44AE600D50AF4 /* DecodeOperators.swift in Sources */,
+				3EA176DE20E44AE600D50AF4 /* JSON.swift in Sources */,
+				3EA176DF20E44AE600D50AF4 /* Decodable.swift in Sources */,
+				3EA176E020E44AE600D50AF4 /* DecodableExtensions.swift in Sources */,
+				3EA176E120E44AE600D50AF4 /* Encodable.swift in Sources */,
+				3EA176E220E44AE600D50AF4 /* EncodableExtensions.swift in Sources */,
+				3EA176E320E44AE600D50AF4 /* EncodeOperators.swift in Sources */,
+				3EA176E420E44AE600D50AF4 /* Decimal.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA0C9F111BF4AD08006459C7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -479,6 +546,63 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		3EA176EA20E44AE600D50AF4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELCodable/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELCodable;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
+				PRODUCT_NAME = ELCodable;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		3EA176EB20E44AE600D50AF4 /* QADeployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELCodable/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELCodable;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
+				PRODUCT_NAME = ELCodable;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = QADeployment;
+		};
+		3EA176EC20E44AE600D50AF4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELCodable/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.walmartlabs.ELCodable;
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
+				PRODUCT_NAME = ELCodable;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
 		CA0C9F281BF4AD08006459C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -870,6 +994,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3EA176E920E44AE600D50AF4 /* Build configuration list for PBXNativeTarget "ELCodable_static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3EA176EA20E44AE600D50AF4 /* Debug */,
+				3EA176EB20E44AE600D50AF4 /* QADeployment */,
+				3EA176EC20E44AE600D50AF4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		CA0C9F101BF4AD08006459C7 /* Build configuration list for PBXProject "ELCodable" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ github "Electrode-iOS/ELCodable"
 
 ### Manual
 
-Install manually by adding `ELCodable.xcodeproj` to your project and configuring your target to link `ELCodable.framework`.
+Install manually by adding `ELCodable.xcodeproj` to your project and configuring your target to link `ELCodable.framework` from `ELCodable` target.
+
+There are two target that builds `ELCodable.framework`.
+1. `ELCodable`: Creates dynamicly linked `ELCodable.framework.`
+2. `ELCodable_static`: Creates staticly linked `ELCodable.framework`.
+
+Both targets build the same product (`ELCodable.framework`), thus linking the same app against both `ELCodable` and `ELCodable_static` should be avoided.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ github "Electrode-iOS/ELCodable"
 Install manually by adding `ELCodable.xcodeproj` to your project and configuring your target to link `ELCodable.framework` from `ELCodable` target.
 
 There are two target that builds `ELCodable.framework`.
-1. `ELCodable`: Creates dynamicly linked `ELCodable.framework.`
-2. `ELCodable_static`: Creates staticly linked `ELCodable.framework`.
+1. `ELCodable`: Creates dynamically linked `ELCodable.framework.`
+2. `ELCodable_static`: Creates statically linked `ELCodable.framework`.
 
 Both targets build the same product (`ELCodable.framework`), thus linking the same app against both `ELCodable` and `ELCodable_static` should be avoided.
 


### PR DESCRIPTION
This change adds a new target named `ELCodable_static`. This target builds a static version of `ELCodable.framework.` 
- It shares the same source files as dynamic ELCodable framework and builds a product with the same name. 
- Framework's module name is also the same as that of dynamic framework.
- It uses the same Info.plist file as dynamic framework target.
- Travis script is updated to build both targets and clean before building.

Going forward, `ELCodable_static` framework needs to be managed as well as `ELCodable` target. Sources added or removed, build setting changes, build phase changes should be reflected on `ELCodable_static` target.

